### PR TITLE
Hide syllabus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+canvas-ext
+==========
+
+This repo hosts custom global JavaScript for DCE Canvas.
+
+Right now, it does two things:
+
+- Sets up a message handler to respond to iframes' request to change their heights and…changes their heights.
+
+- Hides the table on a syllabus page if the maintainer of the course puts an HTML element in their syllabus description with the id 'hide-syllabus-table'.
+
+If you extend it to do any additional things, we *must* break it up into modules. (Don't worry! It's not a big deal; ask Jim.)

--- a/README.md
+++ b/README.md
@@ -10,3 +10,9 @@ Right now, it does two things:
 - Hides the table on a syllabus page if the maintainer of the course puts an HTML element in their syllabus description with the id 'hide-syllabus-table'.
 
 If you extend it to do any additional things, we *must* break it up into modules. (Don't worry! It's not a big deal; ask Jim.)
+
+Deployment
+----------
+
+- Configure the Canvas instances to use https://harvard-dce.github.io/canvas-ext/ext.js as the global JavaScript file.
+- Merge master to the gh-pages branch and push it back to GitHub.

--- a/ext.js
+++ b/ext.js
@@ -1,33 +1,46 @@
-
-
-window.addEventListener('message', handleMessage, false);
-
-function handleMessage(e) {
-  try {
-    if (e.data && e.data.height.length > 2 && e.data.request === 'changeHeight') {
-      console.log('resizing to : ' + e.data.height);
-      var iframe = findIframe(e.data.href);
-      if (iframe) {
-        iframe.style.height = e.data.height;
-     }
-      else {
-        console.log('Could not find iframe with href', e.data.href);
+((function extScope() {
+  function handleMessage(e) {
+    try {
+      if (e.data && e.data.height.length > 2 && e.data.request === 'changeHeight') {
+        console.log('resizing to : ' + e.data.height);
+        var iframe = findIframe(e.data.href);
+        if (iframe) {
+          iframe.style.height = e.data.height;
+       }
+        else {
+          console.log('Could not find iframe with href', e.data.href);
+        }
+      } else {
+        console.log('Missing e.data or e.data.request or proper e.data.height');
       }
-    } else {
-      console.log('Missing e.data or e.data.request or proper e.data.height');
+    } catch (e){
+      console.log('Caught error: ' , e, e.stack);
     }
-  } catch (e){
-    console.log('Caught error: ' , e, e.stack);
   }
-}
 
-function findIframe(href) {
-  var iframes = document.querySelectorAll('iframe');
-  for (var i = 0; i < iframes.length; ++i) {
-    var iframe = iframes[i];
-    if (iframe.src === href) {
-      return iframe;
+  function findIframe(href) {
+    var iframes = document.querySelectorAll('iframe');
+    for (var i = 0; i < iframes.length; ++i) {
+      var iframe = iframes[i];
+      if (iframe.src === href) {
+        return iframe;
+      }
     }
   }
-}
-  
+
+  function hideSyllabusTableIfFlagExists() {
+    var flag = document.querySelector('#hide-syllabus-table');
+    if (flag) {
+      var syllabusEl = document.querySelector('#syllabusContainer');
+      if (syllabusEl) {
+        syllabusEl.parentElement.removeChild(syllabusEl);
+      }
+    }
+  }
+
+  ((function init() {
+    window.addEventListener('message', handleMessage, false);
+    hideSyllabusTableIfFlagExists();
+  })());
+
+})());


### PR DESCRIPTION
In order to support some course managers wanting to hide the syllabus table, we have added the `hideSyllabusTableIfFlagExists` function. It destroys the table element if the user puts an html element (preferably an `a` so that switching to the Canvas Rich Text Editor does not obliterate it) with the id `hide-syllabus-table` in their syllabus description.

Also, wrapped everything in an IIFE to avoid polluting global space and added an init function to start both.

Caveat: The table will appear for a moment and then disappear. There is a more complex approach that can address that, but first, we are going to get stakeholder feedback.
